### PR TITLE
Save IDMap on runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,12 +37,10 @@ export default (extensionReference, forceDownload = false) => {
   return downloadChromeExtension(chromeStoreID, forceDownload)
     .then((extensionFolder) => {
       const name = (remote || electron).BrowserWindow.addDevToolsExtension(extensionFolder); // eslint-disable-line
-      fs.writeFileSync(
-        IDMapPath,
-        JSON.stringify(Object.assign(IDMap, {
-          [chromeStoreID]: name,
-        }))
-      );
+      IDMap = Object.assign(IDMap, {
+        [chromeStoreID]: name,
+      });
+      fs.writeFileSync(IDMapPath, JSON.stringify(IDMap));
       return Promise.resolve(name);
     });
 };


### PR DESCRIPTION
Currently it only save one extension `id, name` to `IDMap.json`.