### PR TITLE
Remove extension if already installed with forceDownload

### DIFF
--- a/test/fixtures/simple_extension/manifest.json
+++ b/test/fixtures/simple_extension/manifest.json
@@ -1,0 +1,6 @@
+{
+  "manifest_version": 2,
+  "name": "React Developer Tools",
+  "description": "Adds React debugging tools to the Chrome Developer Tools.",
+  "version": "0.14.0"
+}

--- a/test/install_spec.js
+++ b/test/install_spec.js
@@ -3,6 +3,8 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiFs from 'chai-fs';
 import { given } from 'mocha-testdata';
+import path from 'path';
+import { BrowserWindow } from 'electron';
 
 // Actual Test Imports
 import installExtension, { REACT_DEVELOPER_TOOLS } from '../src/';
@@ -24,6 +26,24 @@ describe('Extension Installer', () => {
           .then(() => installExtension(REACT_DEVELOPER_TOOLS))
           .then(() => done())
           .catch(() => done('Failed to resolve'));
+      });
+
+      it('should upgraded the extension with forceDownload', (done) => {
+        const extensionName = 'React Developer Tools';
+        const oldVersion = '0.14.0';
+        BrowserWindow.removeDevToolsExtension(extensionName);
+        BrowserWindow.addDevToolsExtension(path.join(__dirname, 'fixtures/simple_extension'))
+          .should.be.equal(extensionName);
+        BrowserWindow.getDevToolsExtensions()[extensionName].version
+          .should.be.equal(oldVersion);
+
+        installExtension(REACT_DEVELOPER_TOOLS, true)
+          .then(() => {
+            BrowserWindow.getDevToolsExtensions()[extensionName].version
+              .should.not.be.equal(oldVersion);
+            done();
+          })
+          .catch(err => done(err));
       });
     });
   });


### PR DESCRIPTION
Currently I cannot upgrade the extension to latest version with forceDownload, it still using old version on the Electron runtime. I think it should remove already installed extension first.